### PR TITLE
add Blog model

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -10,8 +10,21 @@ class User(db.Model):
     email = db.Column(db.String(120), unique=True, nullable=False)
     hashed_password = db.Column(db.String(120), nullable=False)
 
+    blogs = db.relationship("Blog", backref="author", lazy="dynamic")
+
     def set_password(self, password):
         self.hashed_password = generate_password_hash(password)
 
     def check_password(self, password):
         return check_password_hash(self.hashed_password, password)
+
+
+class Blog(db.Model):
+    __tablename__ = "blogs"
+
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200), nullable=False)
+    content = db.Column(db.Text, nullable=False)
+    created_at = db.Column(db.DateTime, server_default=db.func.now())
+
+    author_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)


### PR DESCRIPTION
## Summary

This PR introduces the `Blog` model, which will serve as the core content structure for the personal blog application. It defines the schema and relationships needed to manage blog posts authored by the single seeded admin user.

## What's added

- Added `Blog` model with the following fields:
   - `id`, `title`, `content`, `created_at`, `author_id`
- Added SQLAlchemy relationship to associate a blog post with its author

## Notes:
- Each blog post is tied to a single user via the `author_id` foreign key
- No blog creation routes or views added yet — this is strictly the model layer
- Future PRs will introduce CRUD functionality for blogs