### PR TITLE
add Blog CRUD

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -28,3 +28,15 @@ class Blog(db.Model):
     created_at = db.Column(db.DateTime, server_default=db.func.now())
 
     author_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "title": self.title,
+            "content": self.content,
+            "author": {
+                "id": self.author.id,
+                "username": self.author.username,
+            },
+            "created_at": self.created_at.isoformat(),
+        }

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,70 @@
+from flask import Blueprint, request, flash
+from app import db
+from app.models import Blog, User
+
+
+routes_bp = Blueprint("", __name__)
+
+
+@routes_bp.route("/new", methods=["POST"])
+def create_blog():
+    user = User.query.first()
+
+    blog = Blog(
+        title=request.form.get("title"),
+        content=request.form.get("content"),
+        author_id=user.id,
+    )
+
+    db.session.add(blog)
+    db.session.commit()
+
+    data = blog.to_dict()
+
+    flash("Blog created successfully", "success")
+    return data
+
+
+@routes_bp.route("/", methods=["GET"])
+def get_blogs():
+    blogs = Blog.query.all()
+
+    data = {
+        "blogs": [blog.to_dict() for blog in blogs],
+        "total": len(blogs),
+    }
+
+    return data
+
+
+@routes_bp.route("/<int:blog_id>", methods=["GET"])
+def get_blog(blog_id):
+    blog = Blog.query.get_or_404(blog_id)
+    data = blog.to_dict()
+    return data
+
+
+@routes_bp.route("/delete/<int:blog_id>", methods=["POST"])
+def delete_blog(blog_id):
+    blog = Blog.query.get_or_404(blog_id)
+
+    db.session.delete(blog)
+    db.session.commit()
+
+    flash("Blog deleted successfully", "success")
+    return
+
+
+@routes_bp.route("/edit/<int:blog_id>", methods=["POST"])
+def update_blog(blog_id):
+    blog = Blog.query.get_or_404(blog_id)
+
+    blog.title = request.form.get("title")
+    blog.content = request.form.get("content")
+
+    db.session.commit()
+
+    data = blog.to_dict()
+
+    flash("Blog updated successfully", "success")
+    return data


### PR DESCRIPTION
## Summary

This pull request implements the core backend routes to handle creating, reading, updating, and deleting blog posts within the Flask application. These routes are designed to support server-side rendered templates and form submissions for managing blogs.

## Details:

- Added a Flask Blueprint to encapsulate routes.
- Implemented routes for `Blog` CRUD operations, handling form data from HTML forms:
  - `POST /new`: Creates a new blog using form data (title and content). Currently, assigns the author as the first user in the database.
  - `GET /`: Retrieves all blog posts to be displayed on a blog listing page.
  - `GET /<blog_id>`: Retrieves a specific blog post for detailed viewing.
  - `POST /delete/<blog_id>`: Deletes a blog post upon form submission.
  - `POST /edit/<blog_id>`: Updates an existing blog post with submitted form data.
- Uses SQLAlchemy ORM for database interactions.
- Uses Flask’s flash messaging to send success messages after create, update, and delete actions.
- Returns Python dictionaries representing blog data, which can be passed to templates for rendering.